### PR TITLE
Make withPage() and withContext() public

### DIFF
--- a/src/core/playwright.ts
+++ b/src/core/playwright.ts
@@ -253,13 +253,13 @@ export class Playwright extends Interceptor {
     this.appliedPlaywright = true;
   }
 
-  private withPage(page: Page) {
+  withPage(page: Page) {
     this.page = page;
 
     return this;
   }
 
-  private withContext(context: BrowserContext) {
+  withContext(context: BrowserContext) {
     this.context = context;
 
     return this;


### PR DESCRIPTION
## Regression Fix: Make `withPage` and `withContext` public on `Playwright` interceptor

### Problem

`withPage()` and `withContext()` are documented as public chainable methods in the README:

```ts
await interceptor.withPage(page).enable();
await interceptor.withContext(context).enable();
```

However, in v0.8.0 both methods are declared `private` in `src/core/playwright.ts`, causing a TypeScript compile error for any consumer trying to use the fluent API — even though the methods work correctly at runtime.

### Root Cause

PR #53 refactored the `Playwright` class to add `enableForPage`/`enableForContext` as convenience wrappers. During that refactor, `withPage` and `withContext` were moved to the bottom of the class and accidentally marked `private`. The runtime behavior is unchanged. Only the visibility modifier was wrong.

### Fix

Remove the `private` modifier from `withPage` and `withContext`.

### Testing

- `npx tsc --noEmit` — passes with no errors
- `npm test` — 105/105 tests pass

Closes: https://github.com/Stoobly/stoobly-js/issues/56