### PR TITLE
65 per url openapi specification path via x stoobly openapi specification path

### DIFF
--- a/e2e/cypress/interceptor.spec.js
+++ b/e2e/cypress/interceptor.spec.js
@@ -1,9 +1,12 @@
 import { 
   MATCH_RULES,
+  OPENAPI_SPECIFICATION_PATH,
   PROXY_MODE,
+  PUBLIC_DIRECTORY_PATH,
   RECORD_ORDER,
   RECORD_POLICY,
   RECORD_STRATEGY,
+  RESPONSE_FIXTURES_PATH,
   REWRITE_RULES,
   SCENARIO_KEY,
   SCENARIO_NAME,
@@ -460,6 +463,67 @@ describe('disable', () => {
       const responseBody = interception.response?.body || {};
       expect(responseBody[SCENARIO_KEY.toLowerCase()]).to.be.undefined;
       expect(responseBody[SESSION_ID.toLowerCase()]).to.be.undefined;
+    });
+  });
+});
+
+describe('InterceptorUrl', () => {
+  const stooblyInterceptor = buildStooblyInterceptor();
+  const headersUrl = `${SERVER_URL}/headers`;
+  const apiDataUrl = `${SERVER_URL}/api/data`;
+
+  it('does not set url-specific option headers when InterceptorUrl has only a pattern', () => {
+    stooblyInterceptor.enable({ urls: [{ pattern: headersUrl }] });
+
+    cy.intercept('GET', `${headersUrl}`).as('getHeaders');
+    cy.visit(SERVER_URL);
+
+    cy.wait('@getHeaders').then((interception) => {
+      const responseBody = interception.response?.body || {};
+
+      expect(responseBody[SESSION_ID.toLowerCase()]).to.exist;
+      expect(responseBody[MATCH_RULES.toLowerCase()]).to.be.undefined;
+      expect(responseBody[REWRITE_RULES.toLowerCase()]).to.be.undefined;
+      expect(responseBody[PUBLIC_DIRECTORY_PATH.toLowerCase()]).to.be.undefined;
+      expect(responseBody[RESPONSE_FIXTURES_PATH.toLowerCase()]).to.be.undefined;
+      expect(responseBody[OPENAPI_SPECIFICATION_PATH.toLowerCase()]).to.be.undefined;
+    });
+  });
+
+  it('applies headers from the InterceptorUrl that matches the request URL', () => {
+    const rulesForHeaders = [{ modes: [InterceptMode.replay], components: 'Header' }];
+    const rulesForApi = [{ modes: [InterceptMode.replay], components: 'Body' }];
+    const publicA = '/public-a';
+    const publicB = '/public-b';
+
+    stooblyInterceptor.enable({
+      urls: [
+        { pattern: headersUrl, matchRules: rulesForHeaders, publicDirectoryPath: publicA },
+        { pattern: apiDataUrl, matchRules: rulesForApi, publicDirectoryPath: publicB },
+      ],
+    });
+
+    cy.intercept('GET', `${headersUrl}`).as('getHeaders');
+    cy.intercept('GET', `${apiDataUrl}`).as('getApiData');
+
+    cy.visit(SERVER_URL);
+
+    cy.wait('@getHeaders').then((interception) => {
+      const body = interception.response?.body || {};
+      const encoded = body[MATCH_RULES.toLowerCase()];
+      expect(JSON.parse(atob(encoded))).to.deep.equal(rulesForHeaders);
+      expect(body[PUBLIC_DIRECTORY_PATH.toLowerCase()]).to.equal(publicA);
+    });
+
+    cy.window().then((win) => {
+      win.fetch(apiDataUrl);
+    });
+
+    cy.wait('@getApiData').then((interception) => {
+      const body = interception.response?.body || {};
+      const encoded = body[MATCH_RULES.toLowerCase()];
+      expect(JSON.parse(atob(encoded))).to.deep.equal(rulesForApi);
+      expect(body[PUBLIC_DIRECTORY_PATH.toLowerCase()]).to.equal(publicB);
     });
   });
 });

--- a/e2e/playwright/interceptor.spec.js
+++ b/e2e/playwright/interceptor.spec.js
@@ -2,10 +2,13 @@ import { test, expect } from './fixtures/stoobly';
 
 import { 
   MATCH_RULES,
+  OPENAPI_SPECIFICATION_PATH,
   PROXY_MODE,
+  PUBLIC_DIRECTORY_PATH,
   RECORD_ORDER,
   RECORD_POLICY,
   RECORD_STRATEGY,
+  RESPONSE_FIXTURES_PATH,
   REWRITE_RULES,
   SCENARIO_KEY,
   SCENARIO_NAME,
@@ -516,6 +519,71 @@ test.describe('clear', () => {
 
     // All clears completed without throwing errors
     expect(true).toBe(true);
+  });
+});
+
+test.describe('InterceptorUrl', () => {
+  const headersUrl = `${SERVER_URL}/headers`;
+  const apiDataUrl = `${SERVER_URL}/api/data`;
+
+  test('does not set url-specific option headers when InterceptorUrl has only a pattern', async ({
+    page,
+    stooblyInterceptor,
+  }) => {
+    await stooblyInterceptor.enableForPage(page, {
+      urls: [{ pattern: headersUrl }],
+    });
+
+    page.goto(headersUrl);
+
+    const response = await page.waitForResponse(
+      (r) => r.url().startsWith(headersUrl) && r.status() === 200
+    );
+    const body = await response.json();
+
+    expect(body[SESSION_ID.toLowerCase()]).toBeDefined();
+    expect(body[MATCH_RULES.toLowerCase()]).toBeUndefined();
+    expect(body[REWRITE_RULES.toLowerCase()]).toBeUndefined();
+    expect(body[PUBLIC_DIRECTORY_PATH.toLowerCase()]).toBeUndefined();
+    expect(body[RESPONSE_FIXTURES_PATH.toLowerCase()]).toBeUndefined();
+    expect(body[OPENAPI_SPECIFICATION_PATH.toLowerCase()]).toBeUndefined();
+  });
+
+  test('applies headers from the InterceptorUrl that matches the request URL', async ({
+    page,
+    stooblyInterceptor,
+  }) => {
+    const rulesForHeaders = [{ modes: [InterceptMode.replay], components: 'Header' }];
+    const rulesForApi = [{ modes: [InterceptMode.replay], components: 'Body' }];
+    const publicA = '/public-a';
+    const publicB = '/public-b';
+
+    await stooblyInterceptor.enableForPage(page, {
+      urls: [
+        { pattern: headersUrl, matchRules: rulesForHeaders, publicDirectoryPath: publicA },
+        { pattern: apiDataUrl, matchRules: rulesForApi, publicDirectoryPath: publicB },
+      ],
+    });
+
+    page.goto(headersUrl);
+    const res1 = await page.waitForResponse(
+      (r) => r.url().startsWith(headersUrl) && r.status() === 200
+    );
+    const body1 = await res1.json();
+    expect(JSON.parse(Buffer.from(body1[MATCH_RULES.toLowerCase()], 'base64').toString('utf-8'))).toEqual(
+      rulesForHeaders
+    );
+    expect(body1[PUBLIC_DIRECTORY_PATH.toLowerCase()]).toEqual(publicA);
+
+    page.goto(apiDataUrl);
+    const res2 = await page.waitForResponse(
+      (r) => r.url().startsWith(apiDataUrl) && r.status() === 200
+    );
+    const body2 = await res2.json();
+    expect(JSON.parse(Buffer.from(body2[MATCH_RULES.toLowerCase()], 'base64').toString('utf-8'))).toEqual(
+      rulesForApi
+    );
+    expect(body2[PUBLIC_DIRECTORY_PATH.toLowerCase()]).toEqual(publicB);
   });
 });
 

--- a/src/constants/custom_headers.ts
+++ b/src/constants/custom_headers.ts
@@ -1,5 +1,6 @@
 export const MATCH_RULES = 'X-Stoobly-Request-Match-Rules';
 export const MOCK_POLICY = 'X-Stoobly-Mock-Policy';
+export const OPENAPI_SPECIFICATION_PATH = 'X-Stoobly-OpenAPI-Specification-Path';
 export const OVERWRITE_ID = 'X-Stoobly-Overwrite-Id';
 export const PROXY_MODE = 'X-Stoobly-Proxy-Mode';
 export const PUBLIC_DIRECTORY_PATH = 'X-Stoobly-Public-Directory-Path';

--- a/src/constants/intercept.ts
+++ b/src/constants/intercept.ts
@@ -13,6 +13,7 @@ export enum FilterAction {
 export enum MockPolicy {
   All = 'all',
   Found = 'found',
+  None = 'none',
 }
 
 export enum RecordOrder {
@@ -22,7 +23,9 @@ export enum RecordOrder {
 
 export enum RecordPolicy {
   All = 'all',
+  Api = 'api',
   Found = 'found',
+  None = 'none',
   NotFound = 'not_found',
 }
 
@@ -42,12 +45,13 @@ export enum RequestParameter {
 }
 
 export enum TestPolicy {
-  All = 'all',
   Found = 'found',
+  None = 'none',
 }
 
 export enum TestStrategy {
+  Custom = 'custom',
+  Contract = 'contract',
   Diff = 'diff',
   Fuzzy = 'fuzzy',
-  Custom = 'custom',
 }

--- a/src/core/__tests__/inteceptor.spec.ts
+++ b/src/core/__tests__/inteceptor.spec.ts
@@ -1,7 +1,7 @@
 import {jest} from '@jest/globals';
 import {SpiedFunction} from 'jest-mock';
 
-import {MATCH_RULES, MOCK_POLICY, OVERWRITE_ID, PROXY_MODE, PUBLIC_DIRECTORY_PATH, RECORD_ORDER, RECORD_POLICY, RECORD_STRATEGY, RESPONSE_FIXTURES_PATH, REWRITE_RULES, SCENARIO_CREATE_IF_MISSING, SCENARIO_KEY, SCENARIO_NAME, SESSION_ID, TEST_TITLE} from '@constants/custom_headers';
+import {MATCH_RULES, MOCK_POLICY, OPENAPI_SPECIFICATION_PATH, OVERWRITE_ID, PROXY_MODE, PUBLIC_DIRECTORY_PATH, RECORD_ORDER, RECORD_POLICY, RECORD_STRATEGY, RESPONSE_FIXTURES_PATH, REWRITE_RULES, SCENARIO_CREATE_IF_MISSING, SCENARIO_KEY, SCENARIO_NAME, SESSION_ID, TEST_TITLE} from '@constants/custom_headers';
 import {InterceptMode, MockPolicy, RecordOrder, RecordPolicy, RecordStrategy, RequestParameter} from '@constants/intercept';
 import {Interceptor} from '@core/interceptor';
 
@@ -358,6 +358,7 @@ describe('Interceptor', () => {
               matchRules: usersMatchRules,
               publicDirectoryPath: '/users-public',
               responseFixturesPath: '/users-fixtures',
+              openApiSpecificationPath: '/users-openapi.yaml',
             },
             {
               pattern: new RegExp(`${allowedOrigin}/api/posts`),
@@ -379,6 +380,7 @@ describe('Interceptor', () => {
         );
         expect(reqHeaders[PUBLIC_DIRECTORY_PATH]).toBe('/users-public');
         expect(reqHeaders[RESPONSE_FIXTURES_PATH]).toBe('/users-fixtures');
+        expect(reqHeaders[OPENAPI_SPECIFICATION_PATH]).toBe('/users-openapi.yaml');
         expect(reqHeaders[REWRITE_RULES]).toBeUndefined();
       });
 
@@ -394,6 +396,7 @@ describe('Interceptor', () => {
         expect(reqHeaders[PUBLIC_DIRECTORY_PATH]).toBe('/posts-public');
         expect(reqHeaders[MATCH_RULES]).toBeUndefined();
         expect(reqHeaders[RESPONSE_FIXTURES_PATH]).toBeUndefined();
+        expect(reqHeaders[OPENAPI_SPECIFICATION_PATH]).toBeUndefined();
       });
     });
   });

--- a/src/core/interceptor.ts
+++ b/src/core/interceptor.ts
@@ -1,4 +1,4 @@
-import { MATCH_RULES, MOCK_POLICY, OVERWRITE_ID, PROXY_MODE, PUBLIC_DIRECTORY_PATH, RECORD_ORDER, RECORD_POLICY, RECORD_STRATEGY, RESPONSE_FIXTURES_PATH, REWRITE_RULES, SCENARIO_CREATE_IF_MISSING, SCENARIO_KEY, SCENARIO_NAME, SESSION_ID, TEST_TITLE } from "@constants/custom_headers";
+import { MATCH_RULES, MOCK_POLICY, OPENAPI_SPECIFICATION_PATH, OVERWRITE_ID, PROXY_MODE, PUBLIC_DIRECTORY_PATH, RECORD_ORDER, RECORD_POLICY, RECORD_STRATEGY, RESPONSE_FIXTURES_PATH, REWRITE_RULES, SCENARIO_CREATE_IF_MISSING, SCENARIO_KEY, SCENARIO_NAME, SESSION_ID, TEST_TITLE } from "@constants/custom_headers";
 import { InterceptMode, MockPolicy, RecordOrder, RecordPolicy, RecordStrategy } from "@constants/intercept";
 
 import { InterceptorSettings, InterceptorUrl } from "../types/settings";
@@ -540,8 +540,9 @@ export class Interceptor {
   }
 
   /**
-   * Conditionally applies matchRules, rewriteRules, publicDirectoryPath, and responseFixturesPath
-   * headers from the matching InterceptorUrl when the request URL matches a pattern with these options set.
+   * Conditionally applies matchRules, rewriteRules, publicDirectoryPath, responseFixturesPath,
+   * and openApiSpecificationPath headers from the matching InterceptorUrl when the request URL
+   * matches a pattern with these options set.
    */
   protected applyUrlSpecificHeaders(
     headers: Record<string, string>,
@@ -566,6 +567,9 @@ export class Interceptor {
     }
     if (interceptorUrl.responseFixturesPath) {
       headers[RESPONSE_FIXTURES_PATH] = interceptorUrl.responseFixturesPath;
+    }
+    if (interceptorUrl.openApiSpecificationPath) {
+      headers[OPENAPI_SPECIFICATION_PATH] = interceptorUrl.openApiSpecificationPath;
     }
   }
 

--- a/src/stoobly.ts
+++ b/src/stoobly.ts
@@ -1,4 +1,5 @@
 import { InterceptorFramework } from '@constants/options';
+
 import {DEFAULT_UI_URL} from './constants/config';
 import {Cypress} from './core/cypress';
 import {ConfigResource, HttpService} from './core/http';

--- a/src/types/settings.ts
+++ b/src/types/settings.ts
@@ -25,6 +25,7 @@ export interface InterceptorSettings {
 
 export interface InterceptorUrl {
   matchRules?: MatchRule[];
+  openApiSpecificationPath?: string;
   pattern: RegExp | string;
   publicDirectoryPath?: string;
   responseFixturesPath?: string;

--- a/src/types/settings.ts
+++ b/src/types/settings.ts
@@ -1,6 +1,7 @@
 import { InterceptMode, MockPolicy, RecordOrder, RecordPolicy, RecordStrategy } from "@constants/intercept";
-import { TestFramework } from "../utils/test-detection";
 import { MatchRule, RewriteRule } from "@models/config/types";
+
+import { TestFramework } from "../utils/test-detection";
 
 export interface MockSettings {
   policy?: MockPolicy;


### PR DESCRIPTION
- src/constants/custom_headers.ts — New exported constant OPENAPI_SPECIFICATION_PATH (X-Stoobly-OpenAPI-Specification-Path).
- src/types/settings.ts — InterceptorUrl gains optional openApiSpecificationPath?: string.
- src/core/interceptor.ts — Import OPENAPI_SPECIFICATION_PATH; in applyUrlSpecificHeaders, set that header from interceptorUrl.openApiSpecificationPath when defined; JSDoc updated to include this field alongside match/rewrite rules and fixture paths.