### PR TITLE
Add release drafter and npm publish pipelines

### DIFF
--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -1,0 +1,31 @@
+name-template: '$RESOLVED_VERSION'
+tag-template: '$RESOLVED_VERSION'
+categories:
+  - title: '🚀 Features'
+    labels:
+      - 'feature'
+      - 'enhancement'
+  - title: '🐛 Bug Fixes'
+    labels:
+      - 'fix'
+      - 'bugfix'
+      - 'bug'
+  - title: '🧰 Maintenance'
+    label: 'chore'
+change-template: '- $TITLE @$AUTHOR (#$NUMBER)'
+change-title-escapes: '\<*_&' # You can add # and @ to disable mentions, and add ` to disable code blocks.
+version-resolver:
+  major:
+    labels:
+      - 'major'
+  minor:
+    labels:
+      - 'minor'
+  patch:
+    labels:
+      - 'patch'
+  default: patch
+template: |
+  ## Changes
+
+  $CHANGES

--- a/.github/workflows/publish-npm.yaml
+++ b/.github/workflows/publish-npm.yaml
@@ -1,0 +1,40 @@
+name: Publish to npm
+on:
+  push:
+    tags:
+      - '[0-9]+.[0-9]+.[0-9]+'
+  workflow_dispatch:
+    inputs:
+      skip_publish_npm:
+        description: 'Skip publishing to npm'
+        required: false
+        type: boolean
+        default: false
+
+permissions:
+  id-token: write
+  contents: read
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v6
+
+      - name: Use Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: '24'
+          registry-url: 'https://registry.npmjs.org'
+          package-manager-cache: false
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Test
+        run: npm test
+
+      - name: Publish to npm
+        if: ${{ !inputs.skip_publish_npm }}
+        run: npm publish

--- a/.github/workflows/publish-npm.yaml
+++ b/.github/workflows/publish-npm.yaml
@@ -9,7 +9,7 @@ on:
         description: 'Skip publishing to npm'
         required: false
         type: boolean
-        default: false
+        default: true
 
 permissions:
   id-token: write
@@ -34,6 +34,16 @@ jobs:
 
       - name: Test
         run: npm test
+
+      - name: Verify package.json version matches tag
+        if: github.event_name == 'push'
+        run: |
+          TAG=${GITHUB_REF#refs/tags/}
+          PKG_VERSION=$(node -p "require('./package.json').version")
+          if [ "$TAG" != "$PKG_VERSION" ]; then
+            echo "::error::Tag ($TAG) does not match package.json version ($PKG_VERSION)"
+            exit 1
+          fi
 
       - name: Publish to npm
         if: ${{ !inputs.skip_publish_npm }}

--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -1,0 +1,58 @@
+name: Release Drafter
+
+on:
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: 'git tag and version to create the draft with'
+        required: false
+        type: string
+      publish:
+        description: 'To publish the release or not'
+        required: false
+        type: boolean
+
+  push:
+    branches:
+      - main
+      - master
+
+  # pull_request event is required only for autolabeler
+  pull_request:
+    # Only following types are handled by the action, but one can default to all as well
+    types: [opened, reopened, synchronize]
+    branches:
+      - main
+      - master
+  # pull_request_target event is required for autolabeler to support PRs from forks
+  pull_request_target:
+    types: [opened, reopened, synchronize]
+    branches:
+      - main
+      - master
+
+permissions:
+  contents: read
+
+jobs:
+  update_release_draft:
+    permissions:
+      # write permission is required to create a github release
+      contents: write
+      # write permission is required for autolabeler
+      # otherwise, read permission is required at least
+      pull-requests: write
+    runs-on: ubuntu-latest
+    steps:
+      # Drafts your next Release notes as Pull Requests are merged into "master"
+      - uses: release-drafter/release-drafter@v5
+        # (Optional) specify config name to use, relative to .github/. Default: release-drafter.yml
+        # with:
+        #   config-name: my-config.yml
+        #   disable-autolabeler: true
+        with:
+          tag: ${{ inputs.tag }}
+          version: ${{ inputs.tag }}
+          publish: ${{ inputs.publish }}
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -24,12 +24,6 @@ on:
     branches:
       - main
       - master
-  # pull_request_target event is required for autolabeler to support PRs from forks
-  pull_request_target:
-    types: [opened, reopened, synchronize]
-    branches:
-      - main
-      - master
 
 permissions:
   contents: read


### PR DESCRIPTION
 ## Summary

  - Adds `release-drafter` workflow to auto-draft GitHub release notes as PRs are merged into `main`.
  - Adds `publish-npm` workflow that publishes to npm on semver tag push, authenticated via OIDC (no stored npm
  secret required)
  - Version bumps are resolved automatically from PR labels

  ## How it works

  1. Merge PRs into `main` with appropriate labels → Release Drafter keeps a draft release up to date
  2. When ready to ship, manually trigger **Release Drafter** with a tag (e.g. `0.9.0`) and `publish: true` → creates
   the GitHub release and pushes the tag
  3. Tag push triggers **Publish to npm** → runs tests then `npm publish` via OIDC provenance (no `NPM_TOKEN` secret
  needed)

  ## Prerequisites

  - Enable OIDC publishing for the `stoobly` package on npmjs.com: **Package Settings → Publishing → link to 
  `Stoobly/stoobly-js`**

Closes: #67 